### PR TITLE
accept multiple forms for getMostRecentReport

### DIFF
--- a/src/nootils.js
+++ b/src/nootils.js
@@ -42,7 +42,9 @@ module.exports = function(settings) {
     },
 
     getMostRecentReport: function(reports, forms, fields) {
-      if (!Array.isArray(forms)) return lib.getMostRecentReport(reports, [forms], fields);
+      if (!Array.isArray(forms)) {
+        forms = [forms];
+      }
       let result = null;
       reports.forEach(function(report) {
         if (forms.includes(report.form) &&

--- a/src/nootils.js
+++ b/src/nootils.js
@@ -42,7 +42,7 @@ module.exports = function(settings) {
     },
 
     getMostRecentReport: function(reports, forms, fields) {
-      if (!Array.isArray(forms)) throw 'expecting forms to be a string array';
+      if (!Array.isArray(forms)) return lib.getMostRecentReport(reports, [forms], fields);
       let result = null;
       reports.forEach(function(report) {
         if (forms.includes(report.form) &&

--- a/src/nootils.js
+++ b/src/nootils.js
@@ -44,7 +44,7 @@ module.exports = function(settings) {
     getMostRecentReport: function(reports, form, fields) {
       let result = null;
       reports.forEach(function(report) {
-        if (report.form === form &&
+        if (form.includes(report.form) &&
            !report.deleted &&
            (!result || (report.reported_date > result.reported_date)) &&
            (!fields || (report.fields && lib.fieldsMatch(report, fields)))) {

--- a/src/nootils.js
+++ b/src/nootils.js
@@ -41,10 +41,11 @@ module.exports = function(settings) {
       return report && report.reported_date;
     },
 
-    getMostRecentReport: function(reports, form, fields) {
+    getMostRecentReport: function(reports, forms, fields) {
+      if (!Array.isArray(forms)) throw 'expecting forms to be a string array';
       let result = null;
       reports.forEach(function(report) {
-        if (form.includes(report.form) &&
+        if (forms.includes(report.form) &&
            !report.deleted &&
            (!result || (report.reported_date > result.reported_date)) &&
            (!fields || (report.fields && lib.fieldsMatch(report, fields)))) {

--- a/test/nootils.spec.js
+++ b/test/nootils.spec.js
@@ -68,7 +68,7 @@ describe('Utils', () => {
 
   describe('getMostRecentReport', () => {
     it('returns null on no reports', () => {
-      const actual = nootils.getMostRecentReport([], 'V');
+      const actual = nootils.getMostRecentReport([], ['V']);
       expect(actual).to.eq(null);
     });
 
@@ -76,7 +76,7 @@ describe('Utils', () => {
       const reports = [
         { form: 'H', reported_date: 1 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V');
+      const actual = nootils.getMostRecentReport(reports, ['V']);
       expect(actual).to.eq(null);
     });
 
@@ -85,7 +85,7 @@ describe('Utils', () => {
         { _id: 1, form: 'H', reported_date: 1 },
         { _id: 2, form: 'V', reported_date: 2 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V');
+      const actual = nootils.getMostRecentReport(reports, ['V']);
       expect(actual._id).to.eq(2);
     });
 
@@ -95,7 +95,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2 },
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V');
+      const actual = nootils.getMostRecentReport(reports, ['V']);
       expect(actual._id).to.eq(3);
     });
 
@@ -115,7 +115,7 @@ describe('Utils', () => {
         { _id: 1, form: 'H', reported_date: 1 },
         { _id: 2, form: 'V', reported_date: 2, deleted: true }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V');
+      const actual = nootils.getMostRecentReport(reports, ['V']);
       expect(actual).to.eq(null);
     });
 
@@ -125,7 +125,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false } }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V', { 'screening.malaria': false });
+      const actual = nootils.getMostRecentReport(reports, ['V'], { 'screening.malaria': false });
       expect(actual._id).to.eq(2);
     });
 
@@ -135,7 +135,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false } }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V', { 'screening.malaria': false, dob: '2000-01-01' });
+      const actual = nootils.getMostRecentReport(reports, ['V'], { 'screening.malaria': false, dob: '2000-01-01' });
       expect(actual._id).to.eq(2);
     });
 
@@ -145,7 +145,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false } }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V', { 'screening.malaria': false, dob: '2000-01-02' });
+      const actual = nootils.getMostRecentReport(reports, ['V'], { 'screening.malaria': false, dob: '2000-01-02' });
       expect(actual).to.eq(null);
     });
 
@@ -155,7 +155,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false} }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, 'V', { dob: '2000-01-02' });
+      const actual = nootils.getMostRecentReport(reports, ['V'], { dob: '2000-01-02' });
       expect(actual).to.eq(null);
     });
   });

--- a/test/nootils.spec.js
+++ b/test/nootils.spec.js
@@ -101,10 +101,13 @@ describe('Utils', () => {
 
     it('returns most recent matching report from multiple forms', () => {
       const reports = [
-        { _id: 1, form: 'H', reported_date: 1 },
-        { _id: 2, form: 'V', reported_date: 2 },
+        { _id: 6, form: 'B', reported_date: 9 },
         { _id: 3, form: 'V', reported_date: 3 },
-        { _id: 4, form: 'H', reported_date: 4 }
+        { _id: 4, form: 'H', reported_date: 4 },
+        { _id: 2, form: 'V', reported_date: 2 },
+        { _id: 5, form: 'A', reported_date: 6 },
+        { _id: 1, form: 'H', reported_date: 1 },
+        { _id: 7, form: 'C', reported_date: 12 },
       ];
       const actual = nootils.getMostRecentReport(reports, ['H', 'V']);
       expect(actual._id).to.eq(4);

--- a/test/nootils.spec.js
+++ b/test/nootils.spec.js
@@ -68,7 +68,7 @@ describe('Utils', () => {
 
   describe('getMostRecentReport', () => {
     it('returns null on no reports', () => {
-      const actual = nootils.getMostRecentReport([], ['V']);
+      const actual = nootils.getMostRecentReport([], 'V');
       expect(actual).to.eq(null);
     });
 
@@ -76,7 +76,7 @@ describe('Utils', () => {
       const reports = [
         { form: 'H', reported_date: 1 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V']);
+      const actual = nootils.getMostRecentReport(reports, 'V');
       expect(actual).to.eq(null);
     });
 
@@ -85,7 +85,7 @@ describe('Utils', () => {
         { _id: 1, form: 'H', reported_date: 1 },
         { _id: 2, form: 'V', reported_date: 2 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V']);
+      const actual = nootils.getMostRecentReport(reports, 'V');
       expect(actual._id).to.eq(2);
     });
 
@@ -95,7 +95,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2 },
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V']);
+      const actual = nootils.getMostRecentReport(reports, 'V');
       expect(actual._id).to.eq(3);
     });
 
@@ -115,7 +115,7 @@ describe('Utils', () => {
         { _id: 1, form: 'H', reported_date: 1 },
         { _id: 2, form: 'V', reported_date: 2, deleted: true }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V']);
+      const actual = nootils.getMostRecentReport(reports, 'V');
       expect(actual).to.eq(null);
     });
 
@@ -125,7 +125,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false } }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V'], { 'screening.malaria': false });
+      const actual = nootils.getMostRecentReport(reports, 'V', { 'screening.malaria': false });
       expect(actual._id).to.eq(2);
     });
 
@@ -135,7 +135,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false } }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V'], { 'screening.malaria': false, dob: '2000-01-01' });
+      const actual = nootils.getMostRecentReport(reports, 'V', { 'screening.malaria': false, dob: '2000-01-01' });
       expect(actual._id).to.eq(2);
     });
 
@@ -145,7 +145,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false } }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V'], { 'screening.malaria': false, dob: '2000-01-02' });
+      const actual = nootils.getMostRecentReport(reports, 'V', { 'screening.malaria': false, dob: '2000-01-02' });
       expect(actual).to.eq(null);
     });
 
@@ -155,7 +155,7 @@ describe('Utils', () => {
         { _id: 2, form: 'V', reported_date: 2, fields: { dob: '2000-01-01', screening: { malaria: false} }},
         { _id: 3, form: 'V', reported_date: 3 }
       ];
-      const actual = nootils.getMostRecentReport(reports, ['V'], { dob: '2000-01-02' });
+      const actual = nootils.getMostRecentReport(reports, 'V', { dob: '2000-01-02' });
       expect(actual).to.eq(null);
     });
   });

--- a/test/nootils.spec.js
+++ b/test/nootils.spec.js
@@ -99,6 +99,17 @@ describe('Utils', () => {
       expect(actual._id).to.eq(3);
     });
 
+    it('returns most recent matching report from multiple forms', () => {
+      const reports = [
+        { _id: 1, form: 'H', reported_date: 1 },
+        { _id: 2, form: 'V', reported_date: 2 },
+        { _id: 3, form: 'V', reported_date: 3 },
+        { _id: 4, form: 'H', reported_date: 4 }
+      ];
+      const actual = nootils.getMostRecentReport(reports, ['H', 'V']);
+      expect(actual._id).to.eq(4);
+    });
+
     it('ignores deleted reports', () => {
       const reports = [
         { _id: 1, form: 'H', reported_date: 1 },


### PR DESCRIPTION
Fixes #22
~~This is a breaking change as i changed the type of one of arguments passed to the function (had some bugs without the type change as both strings and arrays have the `includes` method)~~